### PR TITLE
Fix problems when Array prototype is shimmed

### DIFF
--- a/bindonce.js
+++ b/bindonce.js
@@ -102,9 +102,10 @@
 
 				runBinders : function()
 				{
-					for (var data in this.binders)
+					var i, max;
+					for (i = 0, max = this.binders.length; i < max; i ++)
 					{
-						var binder = this.binders[data];
+						var binder = this.binders[i];
 						if (this.group && this.group != binder.group ) continue;
 						var value = binder.scope.$eval((binder.interpolate) ? $interpolate(binder.value) : binder.value);
 						switch(binder.attr)


### PR DESCRIPTION
this.binders is an Array.  When you mess with the prototype and add a function there, then "for (x in theArray)" would return the function you added.  Messing with global objects is bad practice, but it is seen in some 3rd party libraries.

Adding a check here to ensure that we are getting just the properties for the object and not its prototype will solve this issue.  Another solution, which is the direction this patch uses, is to just iterate from 0 through the length of the array.

This minor change fixes issue #20.
