### PR TITLE
Consume binders array as we process it.

### DIFF
--- a/bindonce.js
+++ b/bindonce.js
@@ -101,15 +101,13 @@
 						}
 					},
 
-					runBinders: function ()
+					runBinders : function()
 					{
-						var i, max;
-						for (i = 0, max = this.binders.length; i < max; i++)
-						{
-							var binder = this.binders[i];
-							if (this.group && this.group !== binder.group) continue;
+						while(this.binders.length > 0) {
+							var binder = this.binders.shift();
+							if (this.group && this.group != binder.group ) continue;
 							var value = binder.scope.$eval((binder.interpolate) ? $interpolate(binder.value) : binder.value);
-							switch (binder.attr)
+							switch(binder.attr)
 							{
 								case 'if':
 									if (toBoolean(value))


### PR DESCRIPTION
Ensures that we both process newly added binders from bo-if, and that
we only process each binder once.

Address issue #25
