### PR TITLE
bo-text renders "null" when its value is null

### DIFF
--- a/bindonce.js
+++ b/bindonce.js
@@ -177,7 +177,7 @@
 									classBinder(binder.element, value);
 									break;
 								case 'text':
-									binder.element.text(value);
+									binder.element.text(value === null ? '' : value);
 									break;
 								case 'html':
 									binder.element.html(value);


### PR DESCRIPTION
Angular renders an empty string for nulls.
