### PR TITLE
make sure that bo-html sanitizes html

### DIFF
--- a/bindonce.js
+++ b/bindonce.js
@@ -35,8 +35,9 @@
 		var bindonceDirective =
 		{
 			restrict: "AM",
-			controller: ['$scope', '$element', '$attrs', '$interpolate', '$sce', function ($scope, $element, $attrs, $interpolate, $sce)
+			controller: ['$scope', '$element', '$attrs', '$interpolate', '$injector', '$sce', function ($scope, $element, $attrs, $interpolate, $injector, $sce)
 			{
+                var sanitize = $injector.has('$sanitize');
 				var showHideBinder = function (elm, attr, value)
 				{
 					var show = (attr === 'show') ? '' : 'none';
@@ -180,7 +181,7 @@
 									binder.element.text(value);
 									break;
 								case 'html':
-                                    binder.element.html($sce.getTrustedHtml(value));
+                                    binder.element.html(sanitize ? $sce.getTrustedHtml(value) : value);
 									break;
 								case 'style':
 									binder.element.css(value);

--- a/bindonce.js
+++ b/bindonce.js
@@ -35,7 +35,7 @@
 		var bindonceDirective =
 		{
 			restrict: "AM",
-			controller: ['$scope', '$element', '$attrs', '$interpolate', function ($scope, $element, $attrs, $interpolate)
+			controller: ['$scope', '$element', '$attrs', '$interpolate', '$sce', function ($scope, $element, $attrs, $interpolate, $sce)
 			{
 				var showHideBinder = function (elm, attr, value)
 				{
@@ -180,7 +180,7 @@
 									binder.element.text(value);
 									break;
 								case 'html':
-									binder.element.html(value);
+                                    binder.element.html($sce.getTrustedHtml(value));
 									break;
 								case 'style':
 									binder.element.css(value);


### PR DESCRIPTION
We were finding that if we used bo-html using html strings that contained scripts for example then those scripts would not be stripped as they would with ng-bind-html. 

I'm not sure if this change is something that can be smoothly merged or if there is some reason it is as it is. Particularly not sure if this works in the absence of ngSanitize module. 
