### PR TITLE
Use actual value of attribute refresh-on as event name…

### DIFF
--- a/bindonce.js
+++ b/bindonce.js
@@ -403,7 +403,7 @@
 			{
 				var value = attrs.bindonce && scope.$eval(attrs.bindonce);
 				bindonceController.oneWatcher = attrs.hasOwnProperty('oneWatcher');
-				bindonceController.refreshOn = attrs.refreshOn && scope.$eval(attrs.refreshOn);
+				bindonceController.refreshOn = attrs.refreshOn;
 				bindonceController.keepBinders = bindonceController.oneWatcher || bindonceController.refreshOn;
 
 				if (value !== undefined)


### PR DESCRIPTION
…instead of using `$scope.$eval(attr.refreshOn)`.

I was expecting to be able to do

```
<div bindonce refresh-on="refreshThings">…</div>
```

and then

```
$scope.$broadcast('refreshThings')
```

But the way it's currently written, I need a scope variable  called `refreshThings` whose value defines the name of the event. Is that how it's supposed to work? Maybe I misunderstood your intentions, but the proposed change makes more sense to me.
