### PR TITLE
Check for null before checking bindonce

### DIFF
--- a/bindonce.js
+++ b/bindonce.js
@@ -220,7 +220,7 @@
 			link: function (scope, elm, attrs, bindonceController)
 			{
 				var value = attrs.bindonce && scope.$eval(attrs.bindonce);
-				if (value !== undefined)
+				if (value !== undefined && value !== null)
 				{
 					bindonceController.checkBindonce(value);
 				}


### PR DESCRIPTION
If `value === null` the undefined check will pass, and `checkBindonce` will
attempt to check a null value, and throw JavaScript errors.
