### PR TITLE
This fix the angular 1.3 rc break.

### DIFF
--- a/bindonce.js
+++ b/bindonce.js
@@ -214,7 +214,7 @@
 					}
 				};
 
-				return ctrl;
+				$.extend( this, ctrl );
 			}],
 
 			link: function (scope, elm, attrs, bindonceController)


### PR DESCRIPTION
Since 1.3 rc (actual 1.2.19), you cannot override the directive's controller, but rather extending it.
See https://github.com/angular/angular.js/issues/8876 for more info.
