### PR TITLE
Bindonce fails to handle cases where the bound data is 'null'.

### DIFF
--- a/bindonce.js
+++ b/bindonce.js
@@ -100,7 +100,7 @@
 						var that = this;
 						this.watcherRemover = $scope.$watch(bindonceValue, function (newValue)
 						{
-							if (newValue === undefined) return;
+							if (newValue === null || typeof(newValue) === "undefined") return;
 							that.removeWatcher();
 							that.checkBindonce(newValue);
 						}, true);
@@ -223,7 +223,7 @@
 			link: function (scope, elm, attrs, bindonceController)
 			{
 				var value = attrs.bindonce && scope.$eval(attrs.bindonce);
-				if (value !== undefined)
+				if (value !== null && typeof(value) !== "undefined")
 				{
 					bindonceController.checkBindonce(value);
 				}


### PR DESCRIPTION
In every spot where 'value === undefined' is checked, also check to see if it is null.

Without this change, the bind-once library will throw errors when the initial value of a piece of data is 'null'.

Thanks for the great library!
