### PR TITLE
Emit once bound

### DIFF
--- a/bindonce.js
+++ b/bindonce.js
@@ -212,6 +212,12 @@
 									binder.element.attr(binder.attr, value);
 									break;
 							}
+
+							//emit once bound
+							if (binder.attrs['boEmit']) {
+								binder.scope.$emit('bo-finished');
+							}
+
 						}
 						this.ran = true;
 					}


### PR DESCRIPTION
Added attribute 'boEmit' that allows to specify if bindonce should emit
once bindings are process for a decorator
